### PR TITLE
Some minor fixes and improvements

### DIFF
--- a/src/app-modules/docker-compose
+++ b/src/app-modules/docker-compose
@@ -183,7 +183,7 @@ wait_for_running() {
         sleep "$RUNNING_STATE_TIMEOUT_S"
         $docker_compose_cmd --project-directory "$manifests_dir" ps -q > "$out_tmp"
         count=$(cat "$out_tmp" | wc -l)
-        expected_count=$(docker-compose --project-directory "$manifests_dir" config --images | wc -l)
+        expected_count=$($docker_compose_cmd --project-directory "$manifests_dir" config --images | wc -l)
         if test $count -ge $expected_count; then
             cat "$out_tmp" | xargs -n1 -I{} docker inspect {} | jq -r '.[] | "\(.State.Running) \(.State.Status)"' | grep -qv 'true running'
             if test $? -eq 1; then

--- a/src/app-modules/docker-compose
+++ b/src/app-modules/docker-compose
@@ -174,24 +174,28 @@ wait_for_running() {
     local expected_count
     local rc="$RC_TIMEOUT_STARTING"
     local max_iterations=32
-    local manifests_dir="$1"
+    local application_name="$1"
+    local manifests_dir="$2"
 
     out_tmp=$(mktemp)
     all_running="false"
     i=1
     while test "$all_running" = "false"; do
         sleep "$RUNNING_STATE_TIMEOUT_S"
-        $docker_compose_cmd --project-directory "$manifests_dir" ps -q > "$out_tmp"
-        count=$(cat "$out_tmp" | wc -l)
-        expected_count=$($docker_compose_cmd --project-directory "$manifests_dir" config --images | wc -l)
+        count=$($docker_compose_cmd --project-name "$application_name" \
+            --project-directory "$manifests_dir" \
+            ps --filter="status=running" \
+                                         | wc -l)
+        expected_count=$($docker_compose_cmd --project-name "$application_name" \
+            --project-directory "$manifests_dir" \
+            config --images \
+                            | wc -l)
         if test $count -ge $expected_count; then
-            cat "$out_tmp" | xargs -n1 -I{} docker inspect {} | jq -r '.[] | "\(.State.Running) \(.State.Status)"' | grep -qv 'true running'
-            if test $? -eq 1; then
-                $docker_compose_cmd --project-directory "$manifests_dir" ps -q | xargs -n1 -I{} docker inspect {} | jq -r '.[] | "\(.State.Running) \(.State.Status)"'
-                docker ps
-                rc=0
-                break
-            fi
+            $docker_compose_cmd --project-name $application_name \
+                --project-directory "$manifests_dir" \
+                ps
+            rc=0
+            break
         fi
         i=$(expr $i + 1)
         if test "$i" -gt "$max_iterations"; then
@@ -224,9 +228,11 @@ app_rollout() {
     local rc
     local message
 
-    $docker_compose_cmd --project-directory "$manifests_dir" up -d > "$manifests_dir"/compose.log 2>&1 &
+    $docker_compose_cmd --project-name $application_name \
+        --project-directory "$manifests_dir" \
+        up -d > "$manifests_dir"/compose.log 2>&1 &
     pid=$!
-    wait_for_running "$manifests_dir"
+    wait_for_running "$application_name" "$manifests_dir"
     rc="$?"
     if test "$rc" != "0"; then
         echo "app_rollout failed to start composition, logs follow:" 1>&2
@@ -242,7 +248,9 @@ app_stop() {
     local application_name="$1"
     local manifests_dir="$2"
 
-    $docker_compose_cmd --project-directory "$manifests_dir" down >> "$manifests_dir"/compose.log 2>&1
+    $docker_compose_cmd --project-name "$application_name" \
+        --project-directory "$manifests_dir" \
+        down >> "$manifests_dir"/compose.log 2>&1
 }
 
 app_requirements() {


### PR DESCRIPTION
A more general note I made working with this update module. It seems like we're trying to solve problems that docker compose is already solving: docker compose up will wait until all services are running and startup probe succeeds (if provided). If a container stops seconds later that is beyond control of docker compose and also this module. So my question is, why not map the update module API commands to `docker compose` CLI commands?