### PR TITLE
chore: Change default docker compose to v2 plugin

### DIFF
--- a/src/app-modules/docker-compose
+++ b/src/app-modules/docker-compose
@@ -21,8 +21,12 @@ if test -f "$MODULE_CONFIG_FILE"; then
     . "$MODULE_CONFIG_FILE"
 fi
 
-docker_compose_cmd=${DOCKER_COMPOSE_COMMAND:-"docker-compose"}
 docker_cmd=${DOCKER_COMMAND:-"docker"}
+docker_compose_cmd="${docker_cmd} compose"
+if [ -n "$USE_LEGACY_DOCKER_COMPOSE" ]; then
+  docker_compose_cmd="docker-compose"
+fi
+
 delta_executable=${XDELTA_COMMAND:-"xdelta3"}
 delta_arguments=${XDELTA_ARGS:-"-d -s"}
 delta_cmd="${delta_executable} ${delta_arguments}"


### PR DESCRIPTION
docker-compose v1 is already deprecated, we should use v2 by default.