### PR TITLE
chore: Change default PERSISTENT_STORE to /var/lib/mender/app-modules

### DIFF
--- a/conf/mender-app.conf
+++ b/conf/mender-app.conf
@@ -12,4 +12,4 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
-PERSISTENT_STORE=/data/mender-app
+PERSISTENT_STORE=/var/lib/mender/app-modules

--- a/src/app
+++ b/src/app
@@ -20,15 +20,8 @@ FILES="$2"
 
 temp_dir="$FILES"/tmp
 
-cleanup() {
-    set +e
-    test -f "$PERSISTENT_STORE"/.rw_test && rm -f "$PERSISTENT_STORE"/.rw_test
-}
-
-trap cleanup 1 2 3 6 15
-
 CONFIG_FILE="/etc/mender/mender-app.conf"
-PERSISTENT_STORE="/data/mender-app"
+PERSISTENT_STORE="/var/lib/mender/app-modules"
 APP_MODULE_DIR="/usr/share/mender/app-modules/v1"
 
 version=""
@@ -41,15 +34,6 @@ options=""
 
 if test -f "$CONFIG_FILE"; then
     . "$CONFIG_FILE"
-fi
-
-if test -d "$PERSISTENT_STORE"; then
-    if touch "$PERSISTENT_STORE"/.rw_test; then
-        rm -f "$PERSISTENT_STORE"/.rw_test
-    else
-        echo "ERROR: cant write to persistent_store in $PERSISTENT_STORE"
-        exit 1
-    fi
 fi
 
 CONFIG_HAS_XDELTA3_CMD="xdelta3"
@@ -207,6 +191,7 @@ handle_artifact() {
     # and removing all else
 }
 
+rc=0
 case "$STATE" in
 
     NeedsArtifactReboot)
@@ -218,6 +203,20 @@ case "$STATE" in
         ;;
 
     ArtifactInstall)
+        # Ensure PERSISTENT_STORE exists
+        mkdir -p "$PERSISTENT_STORE"
+        set +e
+        if touch "$PERSISTENT_STORE"/.rw_test; then
+            rm -f "$PERSISTENT_STORE"/.rw_test
+            rc=$?
+            if test $rc -ne 0; then
+                exit $rc
+            fi
+            set -e
+        else
+            echo "ERROR: cant write to persistent_store in $PERSISTENT_STORE" 1>&2
+            exit 1
+        fi
         parse_metadata "$FILES"/header/meta-data "$FILES"/header/header-info
         assert_requirements
         rc=$?

--- a/tests/app/scenarios/00_basic_ArtifactInstall.run.sh
+++ b/tests/app/scenarios/00_basic_ArtifactInstall.run.sh
@@ -34,19 +34,21 @@ tar zxvf "${artifact_dir}"/data/0000.tar.gz -C "${artifact_dir}"
 cp "${artifact_dir}"/images.tar.gz "${files_dir}/"
 cp "${artifact_dir}"/manifests.tar.gz "${files_dir}/"
 
+source conf/mender-app.conf
+
 mkdir -p /usr/share/mender/app-modules/v1
 mkdir -p /usr/share/mender/modules/v3
 cp src/app /usr/share/mender/modules/v3/
 cp src/app-modules/docker-compose /usr/share/mender/app-modules/v1/
 chmod 755 /usr/share/mender/modules/v3/app
 chmod 755 /usr/share/mender/app-modules/v1/docker-compose
-mkdir -p /data/mender-app /etc/mender
+mkdir -p $PERSISTENT_STORE /etc/mender
 cp conf/mender-app.conf /etc/mender/
 /usr/share/mender/modules/v3/app ArtifactInstall "$(dirname ${files_dir})"
 sleep 4
-cat /data/mender-app/mapp64/manifests/*.yml
-cat /data/mender-app/mapp64/manifests/*.log
-grep -rniHF Pulling /data/mender-app/mapp64/manifests/*.log && false
+cat $PERSISTENT_STORE/mapp64/manifests/*.yml
+cat $PERSISTENT_STORE/mapp64/manifests/*.log
+grep -rniHF Pulling $PERSISTENT_STORE/mapp64/manifests/*.log && false
 echo
 sleep 16
 docker ps --format "{{.Image}} {{.Command}}" | sort


### PR DESCRIPTION
The new default aligns better with the mender client paths.