### PR TITLE
ci: added missing variable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,6 +29,12 @@ variables:
     options:
       - "true"
       - "false"
+  GIT_CLIFF:
+    description: "Run git cliff to override the release-please changelog"
+    value: "true"
+    options:
+      - "true"
+      - "false"
 
 stages:
   - test


### PR DESCRIPTION
This variable is needed to optionally skip git cliff, useful in certain debug cases or release-please alignments

Ticket: MC-7477