### PR TITLE
Commit id in the changelog and Commit signoff

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ variables:
     value: "mender-test-bot"
   GITHUB_USER_NAME:
     description: "The Github username for release-please"
-    value: "Mender Test Bot"
+    value: "mender test bot"
   GITHUB_USER_EMAIL:
     description: "The Github user email for release-please"
     value: "mender@northern.tech"

--- a/cliff.toml
+++ b/cliff.toml
@@ -27,7 +27,7 @@ body = """
     {%- for commit in commits | unique(attribute="message") %}
         {%- if commit.scope -%}
         {% else -%}
-            - {{ commit.message | upper_first }} {% if commit.links %}({% for link in commit.links | unique(attribute="text") %}[{{ link.text }}]({{ link.href }}){% endfor -%}){% endif %}
+            - {{ commit.message | upper_first }} {% if commit.links %}({% for link in commit.links | unique(attribute="text") %}[{{ link.text }}]({{ link.href }}){% endfor -%}){% endif %} ([{{ commit.id | truncate(length=7, end="") }}]({{ commit.id }}))
             {% if commit.breaking -%}
             {% raw %}  {% endraw %}- **BREAKING**: {{commit.breaking_description}}
             {% endif -%}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,5 +12,6 @@
   "include-component-in-tag": false,
   "include-v-in-tag": false,
   "bootstrap-sha": "205554ab7d1e2abd38cb030e9ebefaa6174cf4a2",
+  "signoff": "mender test bot <mender@northern.tech>",
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
 }


### PR DESCRIPTION
The user mender-test-bot is creating new changelog commits for both release-please and git cliff, and the test:check-commits is failing because the signoff is not set by default.

Also adding commit.id in the changelog.

Ticket: MEN-7477