### PR TITLE
fix: Fix stopping of previously installed artifact

### DIFF
--- a/src/app
+++ b/src/app
@@ -219,7 +219,7 @@ handle_artifact() {
     done
     # we should check if the app is healthy and alive, then decide what to do
     # at the moment we assume it is alive and ok
-    if test -d "${PERSISTENT_STORE}/${application_name}-previous"; then
+    if test -d "${PERSISTENT_STORE}/${application_name}-previous/manifests"; then
         echo "stopping ${PERSISTENT_STORE}/${application_name}-previous/manifests"
         $app_sub_module STOP "${application_name}" "${PERSISTENT_STORE}/${application_name}-previous/manifests"
     else


### PR DESCRIPTION
This block of code will fail if the `manifests` directory does not exist in the `${PERSISTENT_STORE}/${application_name}-previous` directory. This situation occurred in one of our systems where a previous deployment failed early enough that the `manifests` directory was not created.

https://github.com/mendersoftware/app-update-module/blob/b343feee76f9f0a6167306b2e89451315d8bb562/src/app#L220-L227