### PR TITLE
ci: align changelog job with standards

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,9 +8,6 @@ variables:
   GITHUB_REPO_URL:
     description: "The Github Repo URL for release-please, in the format of 'owner/repo'"
     value: "mendersoftware/app-update-module"
-  GITHUB_USER:
-    description: "The Github user for release-please"
-    value: "mender-test-bot"
   GITHUB_USER_NAME:
     description: "The Github username for release-please"
     value: "mender-test-bot"
@@ -115,6 +112,9 @@ test:acceptancetests:
 changelog:
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/node:20
   stage: changelog
+  variables:
+    GIT_DEPTH: 0  # Always get the full history
+    GIT_STRATEGY: clone  # Always get the full history
   tags:
     - hetzner-amd-beefy
   rules:
@@ -126,23 +126,19 @@ changelog:
     # install release-please
     - npm install -g release-please
     # install github-cli
-    - |
-      mkdir -p -m 755 /etc/apt/keyrings \
-        && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-        && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-        && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-        && apt update \
-        && apt install gh jq -y
+    - mkdir -p -m 755 /etc/apt/keyrings
+    - wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
+    - chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+    - echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+    - apt update
+    - apt install gh jq -y
     # Setting up git
-    - |
-      echo "INFO - setting up git"
-      git config --global user.email "${GITHUB_USER_EMAIL}"
-      git config --global user.name "${GITHUB_USER_NAME}"
+    - git config --global user.email "${GITHUB_USER_EMAIL}"
+    - git config --global user.name "${GITHUB_USER_NAME}"
     - npm install -g git-cliff
     # GITHUB_TOKEN for Github cli authentication
     - export GITHUB_TOKEN=${GITHUB_CLI_TOKEN}
     # getting the centralized git cliff config
-    - wget --output-document cliff.toml https://raw.githubusercontent.com/mendersoftware/mendertesting/master/utils/cliff.toml
   script:
     - release-please release-pr
         --token=${GITHUB_BOT_TOKEN_REPO_FULL}
@@ -150,20 +146,22 @@ changelog:
         --target-branch=${CI_COMMIT_REF_NAME}
     # git cliff: override the changelog
     - test $GIT_CLIFF == "false" && echo "INFO - Skipping git-cliff" && exit 0
-    - git clone https://${GITHUB_USER}:${GITHUB_BOT_TOKEN_REPO_FULL}@github.com/${GITHUB_REPO_URL}
-    - cd ${GITHUB_REPO_URL#*/}
+    - git remote add github-${CI_JOB_ID} https://${GITHUB_USER_NAME}:${GITHUB_BOT_TOKEN_REPO_FULL}@github.com/${GITHUB_REPO_URL} || true  # Ignore already existing remote
+    - gh repo set-default https://${GITHUB_USER_NAME}:${GITHUB_BOT_TOKEN_REPO_FULL}@github.com/${GITHUB_REPO_URL}
     - RELEASE_PLEASE_PR=$(gh pr list --author "${GITHUB_USER_NAME}" --head "release-please--branches--${CI_COMMIT_REF_NAME}" --json number | jq -r '.[0].number // empty')
     - test -z "$RELEASE_PLEASE_PR" && echo "No release-please PR found" && exit 0
-    - echo "INFO - generating changelog notes from git cliff"
-        && gh pr checkout $RELEASE_PLEASE_PR
-        && git cliff --output CHANGELOG.md --bump --github-repo ${GITHUB_REPO_URL}
-        && git add CHANGELOG.md
-        && git commit --amend -s --no-edit
-        && git push origin --force
-    - echo "INFO - updating PR body"
-        && git cliff --unreleased --bump -o tmp_pr_body.md --github-repo ${GITHUB_REPO_URL}
-        && gh pr edit $RELEASE_PLEASE_PR --body-file tmp_pr_body.md
-        && rm tmp_pr_body.md
+    - gh pr checkout --force $RELEASE_PLEASE_PR
+    - wget --output-document cliff.toml https://raw.githubusercontent.com/mendersoftware/mendertesting/master/utils/cliff.toml
+    - git cliff --bump --output CHANGELOG.md --github-repo ${GITHUB_REPO_URL}
+    - git add CHANGELOG.md
+    - git commit --amend -s --no-edit
+    - git push github-${CI_JOB_ID} --force
+    # Update the PR body
+    - git cliff --unreleased --bump -o tmp_pr_body.md --github-repo ${GITHUB_REPO_URL}
+    - gh pr edit $RELEASE_PLEASE_PR --body-file tmp_pr_body.md
+    - rm tmp_pr_body.md
+  after_script:
+    - git remote remove github-${CI_JOB_ID}
 
 release:github:
   image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/node:20


### PR DESCRIPTION
Align this changelog job to the others from other NT projects: always get the full git history, removed duplicated GITHUB_USER, using git fetch github remote instead of a clone.

Ticket: None
Changelog: None