### PR TITLE
feat: skip including image layers in artifact

### DIFF
--- a/gen/app-gen
+++ b/gen/app-gen
@@ -70,7 +70,7 @@ declare -a device_types
 artifact_name=""
 output_path="app-artifact.mender"
 passthrough_args=""
-version="1.1.dev"
+version="1.0"
 orchestrator=""
 k8s_ctr_address=""
 k8s_namespace=""

--- a/gen/app-gen
+++ b/gen/app-gen
@@ -34,6 +34,7 @@ Usage: $0 [options] [-- [options-for-mender-artifact] ]
         --output-path       - Path to output artifact file. Default: reboot-artifact.mender
         --image [current-url,]new-url       - Path to output artifact file. Default: reboot-artifact.mender
         --deep-delta        - Calculate delta by parsing the image
+        --skip-images       - Skip including images in artifact
         --manifests-dir     - Directory containing orchestrator-specific manifests describing the deployment
         --platform          - Platform of the images, e.g.: linux/arm/v7
         --orchestrator      - Name of the orchestrator, and name of the sub-module, e.g.: docker-compose
@@ -78,6 +79,7 @@ manifests_dir=""
 declare -a images=()
 declare -a images_shas=()
 deep_delta=false
+skip_images=false
 
 set +u
 while test $# -gt 0; do
@@ -137,6 +139,10 @@ while test $# -gt 0; do
             images+=($(echo "$2" | cut -f1 -d,)) # current
             images+=($(echo "$2" | cut -f2 -d,)) # new, if current!=new then we need to generate delta.
             shift 2
+            ;;
+        --skip-images | -d)
+            skip_images=true
+            shift 1
             ;;
         --deep-delta | -d)
             deep_delta=true
@@ -209,21 +215,25 @@ if [ -z "${manifests_dir}" ]; then
 fi
 
 if [ ${#images[@]} -lt 1 ]; then
-    if [[ "${orchestrator}" == "${DOCKER_COMPOSE_ORCHESTRATOR}" ]]; then
-        echo "No specific images specified. Will try to extract from docker-compose.yaml file." >&2
+    if [ "$skip_images" == "true" ]; then
+        echo "Skiping including images in artifact"
+    else
+        if [[ "${orchestrator}" == "${DOCKER_COMPOSE_ORCHESTRATOR}" ]]; then
+            echo "No specific images specified. Will try to extract from docker-compose.yaml file." >&2
 
-        while read -r img; do
-            images+=("$img")
-            images+=("$img")
-        done < <( docker compose --project-directory "$manifests_dir" config --images)
+            while read -r img; do
+                images+=("$img")
+                images+=("$img")
+            done < <( docker compose --project-directory "$manifests_dir" config --images)
 
-        if [ ${#images[@]} -lt 1 ]; then
-            echo "Image extraction from docker-compose.yaml failed. Aborting." >&2
+            if [ ${#images[@]} -lt 1 ]; then
+                echo "Image extraction from docker-compose.yaml failed. Aborting." >&2
+                show_help_and_exit_error
+            fi
+        else
+            echo "No images specified. Aborting." >&2
             show_help_and_exit_error
         fi
-    else
-        echo "No images specified. Aborting." >&2
-        show_help_and_exit_error
     fi
 fi
 
@@ -237,7 +247,9 @@ temp_dir="$(mktemp -d)"
     echo "cant get the temporary directory" >&2
     show_help_and_exit_error
 }
-mkdir "${temp_dir}/images"
+if [ "$skip_images" == "false" ]; then
+    mkdir "${temp_dir}/images"
+fi
 
 function cleanup() {
     rm -Rf "$temp_dir"
@@ -539,16 +551,18 @@ generate_metadata() {
     echo -ne '"platform":' >> "${output}"
     printf '"%s",' "$platform" >> "${output}"
     echo -ne '"version":' >> "${output}"
-    printf '"%s",' "$version" >> "${output}"
-    echo -ne '"images":[' >> "${output}"
-    for sha in $(echo "${images_shas[@]}" | tr ' ' '\n' | sort | uniq); do
-        shas+=($sha)
-    done
-    for ((i = 0; i < ${#shas[@]}; i++)); do
-        printf '"%s"' "${shas[${i}]}" >> "${output}"
-        [[ $((i + 1)) -lt ${#shas[@]} ]] && echo -ne "," >> "${output}"
-    done
-    echo -ne ']' >> "${output}"
+    printf '"%s"' "$version" >> "${output}"
+    if [ "$skip_images" == "false" ]; then
+        echo -ne ', "images":[' >> "${output}"
+        for sha in $(echo "${images_shas[@]}" | tr ' ' '\n' | sort | uniq); do
+            shas+=($sha)
+        done
+        for ((i = 0; i < ${#shas[@]}; i++)); do
+            printf '"%s"' "${shas[${i}]}" >> "${output}"
+            [[ $((i + 1)) -lt ${#shas[@]} ]] && echo -ne "," >> "${output}"
+        done
+        echo -ne ']' >> "${output}"
+    fi
     if [[ "${k8s_ctr_address}" != "" || "${k8s_namespace}" != "" ]]; then
         echo -ne ',"env":{' >> "${output}"
         echo -ne "\"K8S_CTR_ADDRESS\":\"${k8s_ctr_address}\"," >> "${output}"
@@ -563,22 +577,38 @@ generate_metadata() {
     echo "--"
 }
 
-prepare_images "${temp_dir}/images"
-( cd "${temp_dir}" && tar czvf images.tar.gz images  )
+if [ "$skip_images" == "false" ]; then
+    prepare_images "${temp_dir}/images"
+    ( cd "${temp_dir}" && tar czvf images.tar.gz images  )
+fi
 cp -a "${manifests_dir}" "${temp_dir}/manifests"
 ( cd "${temp_dir}" && tar czvf "manifests.tar.gz" manifests  )
 generate_metadata "${temp_dir}/metadata.json"
 
-mender-artifact write module-image \
-    -T app \
-    "${device_types[@]}" \
-    -o "$output_path" \
-    -n "$artifact_name" \
-    --meta-data "${temp_dir}/metadata.json" \
-    -f "${temp_dir}/images.tar.gz" \
-    -f "${temp_dir}/manifests.tar.gz" \
-    --software-name "$application_name" \
-    $passthrough_args
+
+if [ "$skip_images" == "false" ]; then
+    mender-artifact write module-image \
+        -T app \
+        "${device_types[@]}" \
+        -o "$output_path" \
+        -n "$artifact_name" \
+        --meta-data "${temp_dir}/metadata.json" \
+        -f "${temp_dir}/images.tar.gz" \
+        -f "${temp_dir}/manifests.tar.gz" \
+        --software-name "$application_name" \
+        $passthrough_args
+else
+    mender-artifact write module-image \
+        -T app \
+        "${device_types[@]}" \
+        -o "$output_path" \
+        -n "$artifact_name" \
+        --meta-data "${temp_dir}/metadata.json" \
+        -f "${temp_dir}/manifests.tar.gz" \
+        --software-name "$application_name" \
+        $passthrough_args
+fi
+
 
 echo "Artifact $output_path generated successfully:"
 mender-artifact read "$output_path"

--- a/gen/app-gen
+++ b/gen/app-gen
@@ -593,29 +593,16 @@ cp -a "${manifests_dir}" "${temp_dir}/manifests"
 ( cd "${temp_dir}" && tar czvf "manifests.tar.gz" manifests  )
 generate_metadata "${temp_dir}/metadata.json"
 
-
-if [ "$skip_images" == "false" ]; then
-    mender-artifact write module-image \
-        -T app \
-        "${device_types[@]}" \
-        -o "$output_path" \
-        -n "$artifact_name" \
-        --meta-data "${temp_dir}/metadata.json" \
-        -f "${temp_dir}/images.tar.gz" \
-        -f "${temp_dir}/manifests.tar.gz" \
-        --software-name "$application_name" \
-        $passthrough_args
-else
-    mender-artifact write module-image \
-        -T app \
-        "${device_types[@]}" \
-        -o "$output_path" \
-        -n "$artifact_name" \
-        --meta-data "${temp_dir}/metadata.json" \
-        -f "${temp_dir}/manifests.tar.gz" \
-        --software-name "$application_name" \
-        $passthrough_args
-fi
+mender-artifact write module-image \
+    -T app \
+    "${device_types[@]}" \
+    -o "$output_path" \
+    -n "$artifact_name" \
+    --meta-data "${temp_dir}/metadata.json" \
+    -f "${temp_dir}/manifests.tar.gz" \
+    $( [ "$skip_images" == "false" ] && echo "-f ${temp_dir}/images.tar.gz" ) \
+    --software-name "$application_name" \
+    $passthrough_args
 
 
 echo "Artifact $output_path generated successfully:"

--- a/gen/app-gen
+++ b/gen/app-gen
@@ -70,7 +70,7 @@ declare -a device_types
 artifact_name=""
 output_path="app-artifact.mender"
 passthrough_args=""
-version="1.0"
+version="1.1.dev"
 orchestrator=""
 k8s_ctr_address=""
 k8s_namespace=""
@@ -215,25 +215,21 @@ if [ -z "${manifests_dir}" ]; then
 fi
 
 if [ ${#images[@]} -lt 1 ]; then
-    if [ "$skip_images" == "true" ]; then
-        echo "Skiping including images in artifact"
-    else
-        if [[ "${orchestrator}" == "${DOCKER_COMPOSE_ORCHESTRATOR}" ]]; then
-            echo "No specific images specified. Will try to extract from docker-compose.yaml file." >&2
+    if [[ "${orchestrator}" == "${DOCKER_COMPOSE_ORCHESTRATOR}" ]]; then
+        echo "No specific images specified. Will try to extract from docker-compose.yaml file." >&2
 
-            while read -r img; do
-                images+=("$img")
-                images+=("$img")
-            done < <( docker compose --project-directory "$manifests_dir" config --images)
+        while read -r img; do
+            images+=("$img")
+            images+=("$img")
+        done < <( docker compose --project-directory "$manifests_dir" config --images)
 
-            if [ ${#images[@]} -lt 1 ]; then
-                echo "Image extraction from docker-compose.yaml failed. Aborting." >&2
-                show_help_and_exit_error
-            fi
-        else
-            echo "No images specified. Aborting." >&2
+        if [ ${#images[@]} -lt 1 ]; then
+            echo "Image extraction from docker-compose.yaml failed. Aborting." >&2
             show_help_and_exit_error
         fi
+    else
+        echo "No images specified. Aborting." >&2
+        show_help_and_exit_error
     fi
 fi
 
@@ -542,6 +538,8 @@ generate_metadata() {
     local -r output="$1"
     local sha
     local -a shas
+    local url
+    local -a urls
 
     echo -ne "{" > "${output}"
     echo -ne '"application_name":' >> "${output}"
@@ -560,6 +558,16 @@ generate_metadata() {
         for ((i = 0; i < ${#shas[@]}; i++)); do
             printf '"%s"' "${shas[${i}]}" >> "${output}"
             [[ $((i + 1)) -lt ${#shas[@]} ]] && echo -ne "," >> "${output}"
+        done
+        echo -ne ']' >> "${output}"
+    else
+        for url in $(echo "${images[@]}" | tr ' ' '\n' | sort | uniq); do
+            urls+=($url)
+        done
+        echo -ne ', "images_urls": [' >> "${output}"
+        for ((i = 0; i < ${#urls[@]}; i++)); do
+            printf '"%s"' "${urls[${i}]}" >> "${output}"
+            [[ $((i + 1)) -lt ${#urls[@]} ]] && echo -ne "," >> "${output}"
         done
         echo -ne ']' >> "${output}"
     fi

--- a/src/app
+++ b/src/app
@@ -38,6 +38,7 @@ app_sub_module=""
 artifact_name=""
 application_name=""
 options=""
+images_urls=()
 
 if test -f "$CONFIG_FILE"; then
     . "$CONFIG_FILE"
@@ -82,6 +83,7 @@ parse_metadata() {
     platform=$(jq -r .platform < "$1")
     export MENDER_APP_UPDATE_MODULE_PLATFORM="$platform"
     orchestrator=$(jq -r .orchestrator < "$1")
+    images_urls=($(jq -r '.images_urls[]?' < "$1"))
     version=$(jq -r .version < "$1")
     app_sub_module="${APP_MODULE_DIR}/${orchestrator}"
     if test ! -f "${app_sub_module}"; then
@@ -225,6 +227,10 @@ handle_artifact() {
             # we save the image urls and shasums in order to be able to clean up
             echo "${url_new}" >> "${PERSISTENT_STORE}/${application_name}"/images/urls
             echo "${sha_new}" >> "${PERSISTENT_STORE}/${application_name}"/images/shas
+        done
+    else
+        for ((i = 0; i < ${#images_urls[@]}; i++)); do
+            echo "${images_urls[${i}]}" >> "${PERSISTENT_STORE}/${application_name}"/images/urls
         done
     fi
     # we should check if the app is healthy and alive, then decide what to do

--- a/src/app
+++ b/src/app
@@ -38,7 +38,6 @@ app_sub_module=""
 artifact_name=""
 application_name=""
 options=""
-images_urls=""
 
 if test -f "$CONFIG_FILE"; then
     . "$CONFIG_FILE"
@@ -83,7 +82,6 @@ parse_metadata() {
     platform=$(jq -r .platform < "$1")
     export MENDER_APP_UPDATE_MODULE_PLATFORM="$platform"
     orchestrator=$(jq -r .orchestrator < "$1")
-    images_urls=($(jq -r '.images_urls[]?' < "$1"))
     version=$(jq -r .version < "$1")
     app_sub_module="${APP_MODULE_DIR}/${orchestrator}"
     if test ! -f "${app_sub_module}"; then
@@ -164,7 +162,7 @@ handle_artifact() {
     echo "decompressing manifests"
     $tar_decompress_cmd "$1"/manifests.tar.gz -C "$temp_dir"
 
-    if [ "$skip_images" == "false" ]; then
+    if test "${skip_images}" = "false"; then
         echo "unpacking images"
         for image_dir in "${temp_dir}/images/"*; do
             echo "unpacking $image_dir"
@@ -212,7 +210,7 @@ handle_artifact() {
     fi
     mkdir -pv "${PERSISTENT_STORE}/${application_name}"/images
     rm -vf "${PERSISTENT_STORE}/${application_name}"/images/*
-    if [ "$skip_images" == "false" ]; then
+    if test "${skip_images}" = "false"; then
         for image_dir in "${temp_dir}/images/"*; do
             echo "scanning ${image_dir}"
             url_current=$(cat "${image_dir}/url-current.txt")
@@ -229,8 +227,8 @@ handle_artifact() {
             echo "${sha_new}" >> "${PERSISTENT_STORE}/${application_name}"/images/shas
         done
     else
-        for ((i = 0; i < ${#images_urls[@]}; i++)); do
-            echo "${images_urls[${i}]}" >> "${PERSISTENT_STORE}/${application_name}"/images/urls
+        jq -r '.images_urls[]?' < "$1" | while IFS= read -r image_url; do
+            echo "$image_url" >> "${PERSISTENT_STORE}/${application_name}/images/urls"
         done
     fi
     # we should check if the app is healthy and alive, then decide what to do

--- a/src/app
+++ b/src/app
@@ -145,54 +145,62 @@ handle_artifact() {
     local deep_delta
     local rollback_id="last"
     local rc=0
+    local skip_images="false"
 
     if test ! -d "$temp_dir"; then
         echo "ERROR: temp_dir does not exist"
         return 1
     fi
 
-    echo "decompressing images"
-    $tar_decompress_cmd "$1"/images.tar.gz -C "$temp_dir"
+    if test -f "$1"/images.tar.gz; then
+        echo "decompressing images"
+        $tar_decompress_cmd "$1"/images.tar.gz -C "$temp_dir"
+    else
+        skip_images="true"
+    fi
+
     echo "decompressing manifests"
     $tar_decompress_cmd "$1"/manifests.tar.gz -C "$temp_dir"
 
-    echo "unpacking images"
-    for image_dir in "${temp_dir}/images/"*; do
-        echo "unpacking $image_dir"
-        url_new=$(cat "${image_dir}/url-new.txt")
-        url_current=$(cat "${image_dir}/url-current.txt")
-        sha_new=$(cat "${image_dir}/sums-new.txt")
-        sha_current=$(cat "${image_dir}/sums-current.txt")
-        if test "$url_new" = ""; then
-            echo "ERROR: payload ${image_dir}/url-new.txt cannot be empty"
-            return 1
-        fi
-        if test "$sha_new" = ""; then
-            echo "ERROR: sha_new cannot be empty"
-            return 1
-        fi
+    if [ "$skip_images" == "false" ]; then
+        echo "unpacking images"
+        for image_dir in "${temp_dir}/images/"*; do
+            echo "unpacking $image_dir"
+            url_new=$(cat "${image_dir}/url-new.txt")
+            url_current=$(cat "${image_dir}/url-current.txt")
+            sha_new=$(cat "${image_dir}/sums-new.txt")
+            sha_current=$(cat "${image_dir}/sums-current.txt")
+            if test "$url_new" = ""; then
+                echo "ERROR: payload ${image_dir}/url-new.txt cannot be empty"
+                return 1
+            fi
+            if test "$sha_new" = ""; then
+                echo "ERROR: sha_new cannot be empty"
+                return 1
+            fi
 
-        if test "$url_new" != "$url_current"; then
-            if test "$url_current" = ""; then
-                echo "ERROR: url_current cannot be empty"
-                return 1
+            if test "$url_new" != "$url_current"; then
+                if test "$url_current" = ""; then
+                    echo "ERROR: url_current cannot be empty"
+                    return 1
+                fi
+                if test "$sha_current" = ""; then
+                    echo "ERROR: sha_ccurrent cannot be empty"
+                    return 1
+                fi
+                if test ! -f "${image_dir}/deep_delta"; then
+                    # deep-delta means that the binary delta was generated at the layers level,
+                    # and the orchestrators submodule will deal with decoding during the LOAD below
+                    # ref. to LOAD implementations
+                    image_current="${temp_dir}/current.${sha_current}.img"
+                    image_new="${temp_dir}/new.${sha_new}.img"
+                    $app_sub_module SAVE "${application_name}" "$url_current" "$image_current"
+                    $delta_cmd "$image_current" "${image_dir}/image.img" "${image_new}"
+                    mv -v "${image_new}" "${image_dir}/image.img"
+                fi
             fi
-            if test "$sha_current" = ""; then
-                echo "ERROR: sha_ccurrent cannot be empty"
-                return 1
-            fi
-            if test ! -f "${image_dir}/deep_delta"; then
-                # deep-delta means that the binary delta was generated at the layers level,
-                # and the orchestrators submodule will deal with decoding during the LOAD below
-                # ref. to LOAD implementations
-                image_current="${temp_dir}/current.${sha_current}.img"
-                image_new="${temp_dir}/new.${sha_new}.img"
-                $app_sub_module SAVE "${application_name}" "$url_current" "$image_current"
-                $delta_cmd "$image_current" "${image_dir}/image.img" "${image_new}"
-                mv -v "${image_new}" "${image_dir}/image.img"
-            fi
-        fi
-    done
+        done
+    fi
     if test -d "${PERSISTENT_STORE}/${application_name}"; then
         echo "copying existing composition to -previous"
         rm -Rf "${PERSISTENT_STORE}/${application_name}-previous"
@@ -202,24 +210,26 @@ handle_artifact() {
     fi
     mkdir -pv "${PERSISTENT_STORE}/${application_name}"/images
     rm -vf "${PERSISTENT_STORE}/${application_name}"/images/*
-    for image_dir in "${temp_dir}/images/"*; do
-        echo "scanning ${image_dir}"
-        url_current=$(cat "${image_dir}/url-current.txt")
-        url_new=$(cat "${image_dir}/url-new.txt")
-        sha_new=$(cat "${image_dir}/sums-new.txt")
-        deep_delta=""
-        if test -f "${image_dir}/deep_delta"; then
-            deep_delta=deep_delta
-        fi
-        MODULE_TMPDIR="${temp_dir}" OPTIONS="${deep_delta}" $app_sub_module LOAD "${application_name}" "${url_new}" "${image_dir}/image.img" "${url_current}"
-        # and the sub module deals with proper image loading
-        # we save the image urls and shasums in order to be able to clean up
-        echo "${url_new}" >> "${PERSISTENT_STORE}/${application_name}"/images/urls
-        echo "${sha_new}" >> "${PERSISTENT_STORE}/${application_name}"/images/shas
-    done
+    if [ "$skip_images" == "false" ]; then
+        for image_dir in "${temp_dir}/images/"*; do
+            echo "scanning ${image_dir}"
+            url_current=$(cat "${image_dir}/url-current.txt")
+            url_new=$(cat "${image_dir}/url-new.txt")
+            sha_new=$(cat "${image_dir}/sums-new.txt")
+            deep_delta=""
+            if test -f "${image_dir}/deep_delta"; then
+                deep_delta=deep_delta
+            fi
+            MODULE_TMPDIR="${temp_dir}" OPTIONS="${deep_delta}" $app_sub_module LOAD "${application_name}" "${url_new}" "${image_dir}/image.img" "${url_current}"
+            # and the sub module deals with proper image loading
+            # we save the image urls and shasums in order to be able to clean up
+            echo "${url_new}" >> "${PERSISTENT_STORE}/${application_name}"/images/urls
+            echo "${sha_new}" >> "${PERSISTENT_STORE}/${application_name}"/images/shas
+        done
+    fi
     # we should check if the app is healthy and alive, then decide what to do
     # at the moment we assume it is alive and ok
-    if test -d "${PERSISTENT_STORE}/${application_name}-previous/manifests"; then
+    if test -d "${PERSISTENT_STORE}/${application_name}-previous"; then
         echo "stopping ${PERSISTENT_STORE}/${application_name}-previous/manifests"
         $app_sub_module STOP "${application_name}" "${PERSISTENT_STORE}/${application_name}-previous/manifests"
     else

--- a/src/app
+++ b/src/app
@@ -235,7 +235,7 @@ handle_artifact() {
     fi
     # we should check if the app is healthy and alive, then decide what to do
     # at the moment we assume it is alive and ok
-    if test -d "${PERSISTENT_STORE}/${application_name}-previous"; then
+    if test -d "${PERSISTENT_STORE}/${application_name}-previous/manifests"; then
         echo "stopping ${PERSISTENT_STORE}/${application_name}-previous/manifests"
         $app_sub_module STOP "${application_name}" "${PERSISTENT_STORE}/${application_name}-previous/manifests"
     else

--- a/src/app
+++ b/src/app
@@ -38,7 +38,7 @@ app_sub_module=""
 artifact_name=""
 application_name=""
 options=""
-images_urls=()
+images_urls=""
 
 if test -f "$CONFIG_FILE"; then
     . "$CONFIG_FILE"


### PR DESCRIPTION
## Description

It would be very usefull having the possibility to skip including images. That means give to docker compose the responsibility to pull the required images through the network directly from the target device.

This fix modifies the metadata:
If the skip-images flag is set, the metadata will include `images_urls` but not the `images` shas.
When the artifact is installed on the target, the app script will look for the `images.tar.gz` file but since it is not included in the artifact, it will not load any image.
The `images_urls` is used for the clean_up function.

https://hub.mender.io/t/suggestion-add-a-skip-images-option-to-app-update-module/7268